### PR TITLE
Δt to dt

### DIFF
--- a/examples/DMD_Examples.jl
+++ b/examples/DMD_Examples.jl
@@ -65,7 +65,7 @@ sol_cont = solve(prob_cont, saveat = 0.1)
 
 plot(sol_cont)
 
-approx_cont = ExactDMD(sol_cont[:,:], Δt = 0.1)
+approx_cont = ExactDMD(sol_cont[:,:], dt = 0.1)
 
 test = dynamics(approx_cont, discrete = false)
 

--- a/src/exact_dmd.jl
+++ b/src/exact_dmd.jl
@@ -17,11 +17,11 @@ mutable struct ExactDMD{M,L,W,F, Q, P} <: abstractKoopmanOperator
 
 end
 
-function ExactDMD(X::AbstractArray; Δt::Float64 = 0.0)
-    return ExactDMD(X[:, 1:end-1], X[:, 2:end], Δt = Δt)
+function ExactDMD(X::AbstractArray; dt::Float64 = 0.0)
+    return ExactDMD(X[:, 1:end-1], X[:, 2:end], dt = dt)
 end
 
-function ExactDMD(X::AbstractArray, Y::AbstractArray; Δt::Float64 = 0.0)
+function ExactDMD(X::AbstractArray, Y::AbstractArray; dt::Float64 = 0.0)
     @assert size(X)[2] .== size(Y)[2]
     @assert size(Y)[1] .<= size(Y)[2]
 
@@ -30,9 +30,9 @@ function ExactDMD(X::AbstractArray, Y::AbstractArray; Δt::Float64 = 0.0)
     # Eigen Decomposition for solution
     Λ, W = eigen(Ã)
 
-    if Δt > 0.0
+    if dt > 0.0
         # Casting Complex enforces results
-        ω = log.(Complex.(Λ)) / Δt
+        ω = log.(Complex.(Λ)) / dt
     else
         ω = []
     end
@@ -75,7 +75,7 @@ end
 
 
 # Update with new measurements
-function update!(m::ExactDMD, x::AbstractArray, y::AbstractArray; Δt::Float64 = 0.0, threshold::Float64 = 1e-3)
+function update!(m::ExactDMD, x::AbstractArray, y::AbstractArray; dt::Float64 = 0.0, threshold::Float64 = 1e-3)
     # Check the error
     ϵ = norm(y - m.Ã*x, 2)
 
@@ -88,9 +88,9 @@ function update!(m::ExactDMD, x::AbstractArray, y::AbstractArray; Δt::Float64 =
     m.Ã = m.Qₖ*inv(m.Pₖ)
     m.λ, m.ϕ = eigen(m.Ã)
 
-    if Δt > 0.0
+    if dt > 0.0
         # Casting Complex enforces results
-        ω = log.(Complex.(m.λ)) / Δt
+        ω = log.(Complex.(m.λ)) / dt
     else
         ω = []
     end

--- a/src/exact_dmd.jl
+++ b/src/exact_dmd.jl
@@ -17,13 +17,14 @@ mutable struct ExactDMD{M,L,W,F, Q, P} <: abstractKoopmanOperator
 
 end
 
-function ExactDMD(X::AbstractArray; dt::Float64 = 0.0)
+function ExactDMD(X::AbstractArray; dt::T = 0.0)    where T <: Real
     return ExactDMD(X[:, 1:end-1], X[:, 2:end], dt = dt)
 end
 
-function ExactDMD(X::AbstractArray, Y::AbstractArray; dt::Float64 = 0.0)
-    @assert size(X)[2] .== size(Y)[2]
-    @assert size(Y)[1] .<= size(Y)[2]
+function ExactDMD(X::AbstractArray, Y::AbstractArray; dt::T = 0.0)  where T <: Real
+    @assert dt >= zero(typeof(dt)) "Provide positive dt"
+    @assert size(X)[2] .== size(Y)[2] "Provide consistent dimensions for data"
+    @assert size(Y)[1] .<= size(Y)[2] "Provide consistent dimensions for data"
 
     # Best Frob norm approximator
     Ã = Y*pinv(X)
@@ -75,7 +76,8 @@ end
 
 
 # Update with new measurements
-function update!(m::ExactDMD, x::AbstractArray, y::AbstractArray; dt::Float64 = 0.0, threshold::Float64 = 1e-3)
+function update!(m::ExactDMD, x::AbstractArray, y::AbstractArray; dt::T = 0.0, threshold::Float64 = 1e-3)  where T <: Real
+    @assert dt >= zero(typeof(dt)) "Provide positive dt"
     # Check the error
     ϵ = norm(y - m.Ã*x, 2)
 

--- a/src/extended_dmd.jl
+++ b/src/extended_dmd.jl
@@ -16,13 +16,14 @@ eigen(m::ExtendedDMD) = eigen(m.koopman)
 eigvals(m::ExtendedDMD) = eigvals(m.koopman)
 eigvecs(m::ExtendedDMD) = eigvecs(m.koopman)
 
-function ExtendedDMD(X::AbstractArray, Ψ::abstractBasis; p::AbstractArray = [],  B::AbstractArray = reshape([], 0,0), dt::Float64 = 1.0)
+function ExtendedDMD(X::AbstractArray, Ψ::abstractBasis; p::AbstractArray = [],  B::AbstractArray = reshape([], 0,0), dt::T = 1.0)  where T <: Real
     return ExtendedDMD(X[:, 1:end-1], X[:, 2:end], Ψ, p = p, B = B, dt = dt)
 end
 
-function ExtendedDMD(X::AbstractArray, Y::AbstractArray, Ψ::abstractBasis; p::AbstractArray = [], B::AbstractArray = reshape([], 0,0), dt::Float64 = 1.0)
-    @assert size(X)[2] .== size(Y)[2]
-    @assert size(Y)[1] .<= size(Y)[2]
+function ExtendedDMD(X::AbstractArray, Y::AbstractArray, Ψ::abstractBasis; p::AbstractArray = [], B::AbstractArray = reshape([], 0,0), dt::T = 1.0) where T <: Real
+    @assert dt >= zero(typeof(dt)) "Provide positive dt"
+    @assert size(X)[2] .== size(Y)[2] "Provide consistent dimensions for data"
+    @assert size(Y)[1] .<= size(Y)[2] "Provide consistent dimensions for data"
 
     # Based upon William et.al. , A Data-Driven Approximation of the Koopman operator
 
@@ -43,7 +44,7 @@ function ExtendedDMD(X::AbstractArray, Y::AbstractArray, Ψ::abstractBasis; p::A
     return ExtendedDMD(Op, B, Ψ)
 end
 
-function update!(m::ExtendedDMD, x::AbstractArray, y::AbstractArray; p::AbstractArray = [], dt::Float64 = 0.0, threshold::Float64 = 1e-3)
+function update!(m::ExtendedDMD, x::AbstractArray, y::AbstractArray; p::AbstractArray = [], dt::T = 0.0, threshold::Float64 = 1e-3) where T <: Real
     Ψ₀ = m.basis(x, p = p)
     Ψ₁ = m.basis(y, p = p)
     update!(m.koopman, Ψ₀, Ψ₁, dt = dt, threshold = threshold)

--- a/src/extended_dmd.jl
+++ b/src/extended_dmd.jl
@@ -16,11 +16,11 @@ eigen(m::ExtendedDMD) = eigen(m.koopman)
 eigvals(m::ExtendedDMD) = eigvals(m.koopman)
 eigvecs(m::ExtendedDMD) = eigvecs(m.koopman)
 
-function ExtendedDMD(X::AbstractArray, Ψ::abstractBasis; p::AbstractArray = [],  B::AbstractArray = reshape([], 0,0), Δt::Float64 = 1.0)
-    return ExtendedDMD(X[:, 1:end-1], X[:, 2:end], Ψ, p = p, B = B, Δt = Δt)
+function ExtendedDMD(X::AbstractArray, Ψ::abstractBasis; p::AbstractArray = [],  B::AbstractArray = reshape([], 0,0), dt::Float64 = 1.0)
+    return ExtendedDMD(X[:, 1:end-1], X[:, 2:end], Ψ, p = p, B = B, dt = dt)
 end
 
-function ExtendedDMD(X::AbstractArray, Y::AbstractArray, Ψ::abstractBasis; p::AbstractArray = [], B::AbstractArray = reshape([], 0,0), Δt::Float64 = 1.0)
+function ExtendedDMD(X::AbstractArray, Y::AbstractArray, Ψ::abstractBasis; p::AbstractArray = [], B::AbstractArray = reshape([], 0,0), dt::Float64 = 1.0)
     @assert size(X)[2] .== size(Y)[2]
     @assert size(Y)[1] .<= size(Y)[2]
 
@@ -43,10 +43,10 @@ function ExtendedDMD(X::AbstractArray, Y::AbstractArray, Ψ::abstractBasis; p::A
     return ExtendedDMD(Op, B, Ψ)
 end
 
-function update!(m::ExtendedDMD, x::AbstractArray, y::AbstractArray; p::AbstractArray = [], Δt::Float64 = 0.0, threshold::Float64 = 1e-3)
+function update!(m::ExtendedDMD, x::AbstractArray, y::AbstractArray; p::AbstractArray = [], dt::Float64 = 0.0, threshold::Float64 = 1e-3)
     Ψ₀ = m.basis(x, p = p)
     Ψ₁ = m.basis(y, p = p)
-    update!(m.koopman, Ψ₀, Ψ₁, Δt = Δt, threshold = threshold)
+    update!(m.koopman, Ψ₀, Ψ₁, dt = dt, threshold = threshold)
     return
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,6 +34,7 @@ end
         push!(y, A*y[end])
     end
     X = hcat(y...)
+    @test_throws AssertionError ExactDMD(X[:, 1:end-2], dt = -1.0)
     estimator = ExactDMD(X[:,1:end-2])
     @test isstable(estimator)
     @test estimator.Ã ≈ A
@@ -48,6 +49,7 @@ end
 
 
 @testset "EDMD" begin
+
     # Test for linear system
     function linear_sys(u, p, t)
         x = -0.9*u[1]
@@ -64,6 +66,7 @@ end
     h = [1u[1]; 1u[2]; sin(u[1]); cos(u[1]); u[1]*u[2]]
     basis = Basis(h, u)
 
+    @test_throws AssertionError ExtendedDMD(sol[:,:], basis, dt = -1.0)
     estimator = ExtendedDMD(sol[:,:], basis)
     @test basis == estimator.basis
     basis_2 = reduce_basis(estimator, threshold = 1e-5)


### PR DESCRIPTION
Allows for non-unicode interface. Otherwise the package will not work on terminals and clusters which don't support unicode, which is a sad reason for a package to not work. Thus in general, it's okay for unicode to be used internally, but there shouldn't be a user-facing requirement to use unicode (like a keyword argument)