### PR TITLE
Add unique method for operations and use simplify_constants 

### DIFF
--- a/src/basis.jl
+++ b/src/basis.jl
@@ -30,7 +30,8 @@ function update!(b::Basis)
     return
 end
 
-function Base.push!(b::Basis, op::Operation)
+function Base.push!(b::Basis, op₀::Operation)
+    op = simplify_constants(op₀)
     push!(b.basis, op)
     # Check for uniqueness
     unique!(b)
@@ -82,6 +83,17 @@ function Base.unique(b::Basis)
     end
     returns = [!r for r in returns]
     return Basis(b.basis[returns], variables(b), parameters = parameters(b))
+end
+
+function Base.unique(b₀::AbstractVector{Operation})
+    b = simplify_constants.(b₀)
+    N = length(b)
+    returns = Vector{Bool}()
+    for i ∈ 1:N
+        push!(returns, any([isequal(b[i], b[j]) for j in i+1:N]))
+    end
+    returns = [!r for r in returns]
+    return b[returns]
 end
 
 function dynamics(b::Basis)

--- a/src/basis.jl
+++ b/src/basis.jl
@@ -14,6 +14,7 @@ function Basis(basis::AbstractVector{Operation}, variables::AbstractVector{Opera
     @assert all(is_independent.(variables)) "Please provide independent variables for base."
 
     bs = unique(basis)
+    fix_single_vars_in_basis!(bs, variables)
 
     vs = sort!([b for b in [ModelingToolkit.vars(bs)...] if !b.known], by = x -> x.name)
     ps = sort!([b for b in [ModelingToolkit.vars(bs)...] if b.known], by = x -> x.name )
@@ -32,6 +33,7 @@ end
 
 function Base.push!(b::Basis, op₀::Operation)
     op = simplify_constants(op₀)
+    fix_single_vars_in_basis!(op, b.variables)
     push!(b.basis, op)
     # Check for uniqueness
     unique!(b)
@@ -94,6 +96,16 @@ function Base.unique(b₀::AbstractVector{Operation})
     end
     returns = [!r for r in returns]
     return b[returns]
+end
+
+function fix_single_vars_in_basis!(basis,variables)
+    for (ind, el) in enumerate(basis)
+        for (ind_var, var) in enumerate(variables)
+            if isequal(el,var)
+                basis[ind] = 1var
+            end
+        end
+    end
 end
 
 function dynamics(b::Basis)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,8 +7,9 @@ using Test
 @testset "Basis" begin
     @variables u[1:3]
     @parameters w[1:2]
-    h = [1u[1]; 1u[2]; cos(w[1]*u[2]+w[2]*u[3]); 1u[3]+1u[2]]
-    basis = Basis(h, u, parameters = w)
+    h = [u[1]; u[2]; cos(w[1]*u[2]+w[2]*u[3]); u[3]+u[2]]
+    h_not_unique = [1u[1]; u[1]; 1u[1]^1; h]
+    basis = Basis(h_not_unique, u, parameters = w)
     basis_2 = unique(basis)
     @test size(basis) == size(h)
     @test basis([1.0; 2.0; π], p = [0. 1.]) ≈ [1.0; 2.0; -1.0; π+2.0]


### PR DESCRIPTION
1) Function `unique` inside the Basis constructor was never being called because the argument's type was AbstractVector{Operation} instead of a Basis.

2) Using simplify_constants since `isequal` was considering things like 1u[1]^1 equal to u[1].